### PR TITLE
The view feedback widget no longer maintains state.

### DIFF
--- a/lib/routes/userRoutes/unregisteredUserRoute.dart
+++ b/lib/routes/userRoutes/unregisteredUserRoute.dart
@@ -106,6 +106,7 @@ class _UnregisteredUserScreenState extends State<UnregisteredUserScreen> {
           _title = "Give feedback";
           break;
         case 1:
+          
           _title = "View your feedback";
           break;
         default:
@@ -175,7 +176,6 @@ class _UnregisteredUserScreenState extends State<UnregisteredUserScreen> {
                 ),
               ),
               Visibility(
-                maintainState: true,
                 visible: _visibleIndex == 1,
                 child: Container(
                   child: _fetchingTokens

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -337,7 +337,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.4"
+    version: "1.3.0-nullsafety.3"
   mime:
     dependency: transitive
     description:
@@ -517,7 +517,7 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.2"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
@@ -603,5 +603,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-213.1.beta"
+  dart: ">=2.10.0-110 <2.11.0"
   flutter: ">=1.12.13+hotfix.6 <2.0.0"


### PR DESCRIPTION
The view feedback widget no longer maintains state. When it is no longer in view it will require a re-render, fetching the feedback list again.

closes #52 